### PR TITLE
[fix] ActiveSupport::Notifications for schema-based tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.12.0] - 2019-09-19
+### Changed
+- Payload for existing ActiveSupport adapter contains both `table` and `schema` fields now. 
+
 ## [1.11.0] - 2019-09-11
 ### Added
 - Receiving: inconsistent events raises `TableSync::UnprovidedEventTargetKeysError`

--- a/docs/synopsis.md
+++ b/docs/synopsis.md
@@ -276,13 +276,14 @@ Types of events available:
 `"tablesync.receive.update"`, `"tablesync.receive.destroy"`, `"tablesync.publish.update"`
 and `"tablesync.publish.destroy"`.
 
-You have access to the payload, which contains  `event`, `direction`, `table` and `count`.
+You have access to the payload, which contains  `event`, `direction`, `table`, `schema` and `count`.
 
 ```
 {
   :event => :update,       # one of update / destroy
   :direction => :publish,  # one of publish / receive
   :table => "users",
+  :schema => "public",  
   :count => 1
 }
 ```

--- a/lib/table_sync.rb
+++ b/lib/table_sync.rb
@@ -24,6 +24,8 @@ module TableSync
   require_relative "./table_sync/model/sequel"
   require_relative "./table_sync/instrument"
   require_relative "./table_sync/instrument_adapter/active_support"
+  require_relative "./table_sync/naming_resolver/active_record"
+  require_relative "./table_sync/naming_resolver/sequel"
 
   class << self
     include Memery

--- a/lib/table_sync/batch_publisher.rb
+++ b/lib/table_sync/batch_publisher.rb
@@ -19,7 +19,8 @@ class TableSync::BatchPublisher < TableSync::BasePublisher
     return unless need_publish?
     Rabbit.publish(params)
 
-    TableSync::Instrument.notify table: TableSync.orm.table_name(object_class), event: event,
+    model_naming = TableSync.orm.model_naming(object_class)
+    TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema, event: event,
                                  count: publishing_data[:attributes].size, direction: :publish
   end
 

--- a/lib/table_sync/batch_publisher.rb
+++ b/lib/table_sync/batch_publisher.rb
@@ -20,7 +20,8 @@ class TableSync::BatchPublisher < TableSync::BasePublisher
     Rabbit.publish(params)
 
     model_naming = TableSync.orm.model_naming(object_class)
-    TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema, event: event,
+    TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema,
+                                 event: event,
                                  count: publishing_data[:attributes].size, direction: :publish
   end
 

--- a/lib/table_sync/instrument_adapter/active_support.rb
+++ b/lib/table_sync/instrument_adapter/active_support.rb
@@ -4,10 +4,11 @@ module TableSync::InstrumentAdapter
   module ActiveSupport
     module_function
 
-    def notify(table:, event:, direction:, count: 1)
+    def notify(table:, schema:, event:, direction:, count: 1)
       ::ActiveSupport::Notifications.instrument "tablesync.#{direction}.#{event}",
                                                 count: count,
                                                 table: table.to_s,
+                                                schema: schema.to_s,
                                                 event: event,
                                                 direction: direction
     end

--- a/lib/table_sync/model/active_record.rb
+++ b/lib/table_sync/model/active_record.rb
@@ -45,8 +45,8 @@ module TableSync::Model
           AND kcu.constraint_name = tc.constraint_name
         WHERE
           t.table_schema NOT IN ('pg_catalog', 'information_schema')
-          AND t.table_schema = '#{model_naming_schema}'
-          AND t.table_name = '#{model_naming_table}'
+          AND t.table_schema = '#{model_naming.schema}'
+          AND t.table_name = '#{model_naming.table}'
         ORDER BY
           kcu.ordinal_position
       SQL
@@ -74,7 +74,7 @@ module TableSync::Model
         end.compact
       end
 
-      TableSync::Instrument.notify(table: model_naming_table, schema: model_naming_schema,
+      TableSync::Instrument.notify(table: model_naming.table, schema: model_naming.schema,
                                    event: :update, count: result.count, direction: :receive)
 
       result
@@ -87,7 +87,7 @@ module TableSync::Model
       end
 
       TableSync::Instrument.notify(
-        table: model_naming_table, schema: model_naming_schema,
+        table: model_naming.table, schema: model_naming.schema,
         event: :destroy, count: result.count, direction: :receive
       )
 
@@ -105,8 +105,6 @@ module TableSync::Model
     private
 
     attr_reader :raw_model
-
-    delegate :table, :schema, to: :model_naming, prefix: true
 
     def db
       @raw_model.connection

--- a/lib/table_sync/model/active_record.rb
+++ b/lib/table_sync/model/active_record.rb
@@ -74,10 +74,8 @@ module TableSync::Model
         end.compact
       end
 
-      TableSync::Instrument.notify(
-        table: model_naming_table, schema: model_naming_schema,
-        event: :update, count: result.count, direction: :receive,
-      )
+      TableSync::Instrument.notify(table: model_naming_table, schema: model_naming_schema,
+                                   event: :update, count: result.count, direction: :receive)
 
       result
     end
@@ -90,7 +88,7 @@ module TableSync::Model
 
       TableSync::Instrument.notify(
         table: model_naming_table, schema: model_naming_schema,
-        event: :destroy, count: result.count, direction: :receive,
+        event: :destroy, count: result.count, direction: :receive
       )
 
       result

--- a/lib/table_sync/model/sequel.rb
+++ b/lib/table_sync/model/sequel.rb
@@ -37,8 +37,7 @@ module TableSync::Model
                       .multi_insert(insert_data)
 
       TableSync::Instrument.notify table: model_naming_table, schema: model_naming_schema,
-                                   count: result.count,
-                                   event: :update, direction: :receive
+                                   count: result.count, event: :update, direction: :receive
       result
     end
 

--- a/lib/table_sync/model/sequel.rb
+++ b/lib/table_sync/model/sequel.rb
@@ -36,14 +36,14 @@ module TableSync::Model
                       )
                       .multi_insert(insert_data)
 
-      TableSync::Instrument.notify table: model_naming_table, schema: model_naming_schema,
+      TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema,
                                    count: result.count, event: :update, direction: :receive
       result
     end
 
     def destroy(data)
       result = dataset.returning.where(data).delete
-      TableSync::Instrument.notify table: model_naming_table, schema: model_naming_schema,
+      TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema,
                                    count: result.count,
                                    event: :destroy, direction: :receive
       result
@@ -60,8 +60,6 @@ module TableSync::Model
     private
 
     attr_reader :raw_model
-
-    delegate :table, :schema, to: :model_naming, prefix: true
 
     def table_name
       raw_model.table_name

--- a/lib/table_sync/naming_resolver/active_record.rb
+++ b/lib/table_sync/naming_resolver/active_record.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module TableSync::NamingResolver
+  class ActiveRecord
+    def initialize(table_name:)
+      @table_name = table_name
+    end
+
+    def table
+      meta_data.last
+    end
+
+    def schema
+      meta_data.size > 1 ? meta_data[-2] : "public"
+    end
+
+    private
+
+    attr_reader :table_name
+
+    def meta_data
+      table_name.to_s.split "."
+    end
+  end
+end

--- a/lib/table_sync/naming_resolver/sequel.rb
+++ b/lib/table_sync/naming_resolver/sequel.rb
@@ -8,20 +8,16 @@ module TableSync::NamingResolver
     end
 
     def table
-      table_name.is_a?(sequel_qualified_class) ? table_name.column : table_name
+      table_name.is_a?(::Sequel::SQL::QualifiedIdentifier) ? table_name.column : table_name
     end
 
     def schema
-      return table_name.table if table_name.is_a?(sequel_qualified_class)
+      return table_name.table if table_name.is_a?(::Sequel::SQL::QualifiedIdentifier)
       db.get(Sequel.function("current_schema")) rescue "public"
     end
 
     private
 
     attr_reader :table_name, :db
-
-    def sequel_qualified_class
-      ::Sequel::SQL::QualifiedIdentifier
-    end
   end
 end

--- a/lib/table_sync/naming_resolver/sequel.rb
+++ b/lib/table_sync/naming_resolver/sequel.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module TableSync::NamingResolver
+  class Sequel
+    def initialize(table_name:, db:)
+      @table_name = table_name
+      @db = db
+    end
+
+    def table
+      table_name.is_a?(sequel_qualified_class) ? table_name.column : table_name
+    end
+
+    def schema
+      return table_name.table if table_name.is_a?(sequel_qualified_class)
+      db.get(Sequel.function("current_schema")) rescue "public"
+    end
+
+    private
+
+    attr_reader :table_name, :db
+
+    def sequel_qualified_class
+      ::Sequel::SQL::QualifiedIdentifier
+    end
+  end
+end

--- a/lib/table_sync/orm_adapter/active_record.rb
+++ b/lib/table_sync/orm_adapter/active_record.rb
@@ -8,6 +8,10 @@ module TableSync::ORMAdapter
       ::TableSync::Model::ActiveRecord
     end
 
+    def model_naming(object)
+      ::TableSync::NamingResolver::ActiveRecord.new(table_name: object.table_name)
+    end
+
     def find(dataset, conditions)
       dataset.find_by(conditions)
     end

--- a/lib/table_sync/orm_adapter/active_record.rb
+++ b/lib/table_sync/orm_adapter/active_record.rb
@@ -20,10 +20,6 @@ module TableSync::ORMAdapter
       object.attributes
     end
 
-    def table_name(object)
-      object.table_name
-    end
-
     def setup_sync(klass, **opts)
       debounce_time = opts.delete(:debounce_time)
 

--- a/lib/table_sync/orm_adapter/sequel.rb
+++ b/lib/table_sync/orm_adapter/sequel.rb
@@ -8,16 +8,16 @@ module TableSync::ORMAdapter
       ::TableSync::Model::Sequel
     end
 
+    def model_naming(object)
+      ::TableSync::NamingResolver::Sequel.new(table_name: object.table_name, db: object.db)
+    end
+
     def find(dataset, conditions)
       dataset.find(conditions)
     end
 
     def attributes(object)
       object.values
-    end
-
-    def table_name(object)
-      object.table_name
     end
 
     def setup_sync(klass, **opts)

--- a/lib/table_sync/publisher.rb
+++ b/lib/table_sync/publisher.rb
@@ -34,7 +34,8 @@ class TableSync::Publisher < TableSync::BasePublisher
     return if !object && !destroyed?
 
     Rabbit.publish(params)
-    TableSync::Instrument.notify table: TableSync.orm.table_name(object_class),
+    model_naming = TableSync.orm.model_naming(object_class)
+    TableSync::Instrument.notify table: model_naming.table, schema: model_naming.schema,
                                  event: event, direction: :publish
   end
 

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "1.11.0"
+  VERSION = "1.12.0"
 end

--- a/spec/features/instrument/receive_spec.rb
+++ b/spec/features/instrument/receive_spec.rb
@@ -136,10 +136,11 @@
               version: 123.34534,
             },
             project_id: "pid",
-            )
+          )
         end
 
-        it_behaves_like "sync notification", table: "clubs", schema: "custom_schema", event_type: :destroy
+        it_behaves_like "sync notification", table: "clubs", schema: "custom_schema",
+                                             event_type: :destroy
       end
     end
 
@@ -196,7 +197,7 @@
               version: 123.34534,
             },
             project_id: "pid",
-            )
+          )
         end
 
         it_behaves_like "sync notification", table: "clubs", schema: "custom_schema", count: 2

--- a/spec/support/database_settings.rb
+++ b/spec/support/database_settings.rb
@@ -78,11 +78,24 @@ DB.run <<~SQL
     "first_sync_time" timestamp without time zone,
     UNIQUE (ext_id, ext_project_id)
   );
+
+  DROP TABLE IF EXISTS "custom_schema"."clubs";
+  DROP SCHEMA IF EXISTS "custom_schema";
+
+  CREATE SCHEMA custom_schema;
+  CREATE TABLE "custom_schema"."clubs" (
+    "id" int primary key,
+    "name" text,
+    "position" int,
+    "version" decimal,
+    "rest" jsonb
+  );
 SQL
 
 RSpec.configure do |config|
   config.before do
-    tables = DB[:pg_tables].where(schemaname: "public").select_map(:tablename)
+    schemas_tables = DB[:pg_tables].where(schemaname: %w[public custom_schema]).select_hash(:tablename, :schemaname)
+    tables = schemas_tables.map { |table, schema| "#{schema}.#{table}" }
     DB.run("TRUNCATE #{tables.join(', ')}")
   end
 end

--- a/spec/support/database_settings.rb
+++ b/spec/support/database_settings.rb
@@ -94,7 +94,8 @@ SQL
 
 RSpec.configure do |config|
   config.before do
-    schemas_tables = DB[:pg_tables].where(schemaname: %w[public custom_schema]).select_hash(:tablename, :schemaname)
+    schemas_tables = DB[:pg_tables].where(schemaname: %w[public custom_schema])
+                                   .select_hash(:tablename, :schemaname)
     tables = schemas_tables.map { |table, schema| "#{schema}.#{table}" }
     DB.run("TRUNCATE #{tables.join(', ')}")
   end


### PR DESCRIPTION
The current `TableSync::Instrument` approach doesn't support schema-based tables.

For example, if you try to receive
`handler.receive("Player", to_table: Sequel[:custom_schema][:players])`
you will see such problem:
```
 expected: "players"
 got: "#<Sequel::SQL::QualifiedIdentifier:0x000055b86b993bc0>"
```

I suggest splitting schema and table names in notifications to receive what you want to expected receive. 