### PR TITLE
[batch_publisher] incorrect attrs_for_metadata definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.13.1] - 2019-03-24
+### Fixed
+- **TableSync::BatchPublisher**: incorrect `attrs_for_metadata` definition (typo in method name);
+
 ## [1.13.0] - 2019-11-02
 ### Added
 - Wrapping interface around receiving logic (`wrap_receiving`);

--- a/lib/table_sync/batch_publisher.rb
+++ b/lib/table_sync/batch_publisher.rb
@@ -57,7 +57,7 @@ class TableSync::BatchPublisher < TableSync::BasePublisher
     {}
   end
 
-  def attr_for_metadata
+  def attrs_for_metadata
     {}
   end
 


### PR DESCRIPTION
Fixed typo in `TableSync::BatchPublisher#attr_for_metadata` method name (missing `attrS`) that causes **NameError** exception:

```ruby
NameError: undefined local variable or method 'attrs_for_metadata' for #<TableSync::BatchPublisher:0x000055a860e5fbd8> Did you mean? attr_for_metadata
```