### PR TITLE
BatchPublisher: options for events and headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.1.0] - 2020-04-09
+### Added
+- **TableSync::BatchPublisher**: custom headers;
+- **TableSync::BatchPublisher**: custom events;
+
+### Changed
+- Slight changes to specs
+
 ## [2.0.0] - 2020-04-06
 ### Changed
 - Sequel publishing hooks: checking for `:destroy` events inside `:if`/`:unless` predicates

--- a/docs/synopsis.md
+++ b/docs/synopsis.md
@@ -103,11 +103,21 @@ And `TableSync.routing_metadata_callable` is not called at all: header value is 
 - `routing_key`, which is a custom key used (if given) to override one from `TableSync.routing_key_callable`, `nil` by default
 - `push_original_attributes` (default value is `false`), if this option is set to `true`,
 original_attributes_array will be pushed to Rabbit instead of fetching records from database and sending their mapped attributes.
+- `headers`, which is an option for custom headers (can be used for headers exchanges routes), `nil` by default
+- `event`, which is an option for event specification (`:destroy` or `:update`), `:update` by default
 
 Example:
 
 ```ruby
-TableSync::BatchPublisher.new("SomeClass", [{ id: 1 }, { id: 2 }], confirm: false, routing_key: "custom_routing_key")
+TableSync::BatchPublisher.new(
+  "SomeClass",
+  [{ id: 1 }, { id: 2 }],
+  confirm: false,
+  routing_key: "custom_routing_key",
+  push_original_attributes: true,
+  headers: { key: :value },
+  event: :destroy,
+)
 ```
 
 # Manual publishing with batches (Russian)
@@ -125,11 +135,21 @@ TableSync::BatchPublisher.new("SomeClass", [{ id: 1 }, { id: 2 }], confirm: fals
 - `confirm`, флаг для RabbitMQ, по умолчанию - `true`
 - `routing_key`, ключ, который (если указан) замещает ключ, получаемый из `TableSync.routing_key_callable`, по умолчанию - `nil`
 - `push_original_attributes` (значение по умолчанию `false`), если для этой опции задано значение true, в Rabbit будут отправлены original_attributes_array, вместо получения значений записей из базы непосредственно перед отправкой.
+- `headers`, опция для задания headers (можно использовать для задания маршрутов в headers exchange'ах), `nil` по умолчанию
+- `event`, опция для указания типа события (`:destroy` или `:update`), `:update` по умолчанию
 
 Example:
 
 ```ruby
-TableSync::BatchPublisher.new("SomeClass", [{ id: 1 }, { id: 2 }], confirm: false, routing_key: "custom_routing_key")
+TableSync::BatchPublisher.new(
+  "SomeClass",
+  [{ id: 1 }, { id: 2 }],
+  confirm: false,
+  routing_key: "custom_routing_key",
+  push_original_attributes: true,
+  headers: { key: :value },
+  event: :destroy,
+)
 ```
 
 # Receiving changes

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "2.0.0"
+  VERSION = "2.1.0"
 end


### PR DESCRIPTION
Allows to set event type (destroy or update, currently only update) and set custom headers (currently only nil).