### PR TITLE
fixed potential data corruption with batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [4.2.2] - 2020-11-20
+### Fixed
+- potential data corruption with batches
+
 ## [4.2.1] - 2020-11-20
 ### Fixed
 - bug with sorting data in handler, it was bad idea to use `.hash` replaced to `.to_s` 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_sync (4.2.1)
+    table_sync (4.2.2)
       memery
       rabbit_messaging (~> 0.3)
       rails

--- a/lib/table_sync/receiving/handler.rb
+++ b/lib/table_sync/receiving/handler.rb
@@ -110,10 +110,10 @@ class TableSync::Receiving::Handler < Rabbit::EventHandler
 
     keys_sample = data[0].keys
     keys_diff = data.each_with_object(Set.new) do |row, set|
-      (row.keys - keys_sample | keys_sample - row.keys).each(&set.method(:add)) 
+      (row.keys - keys_sample | keys_sample - row.keys).each(&set.method(:add))
     end
 
-    if keys_diff.size > 0
+    unless keys_diff.empty?
       raise TableSync::DataError.new(data, target_keys, <<~MESSAGE)
         Bad batch structure, check keys: #{keys_diff.to_a}
       MESSAGE

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "4.2.1"
+  VERSION = "4.2.2"
 end

--- a/spec/receiving/handler_spec.rb
+++ b/spec/receiving/handler_spec.rb
@@ -520,6 +520,42 @@ describe TableSync::Receiving::Handler do
         expect { fire_update_event }.to raise_error(TableSync::DataError)
       end
     end
+
+    describe "error with data structure" do
+      let(:handler) do
+        Class.new(described_class).receive("User", to_table: :users) do
+          target_keys(:id)
+        end
+      end
+
+      let(:update_event) do
+        OpenStruct.new(
+          data: {
+            event: "update",
+            model: "User",
+            attributes: [
+              {
+                id: 1,
+                name: "test1",
+              },
+              {
+                id: 2,
+                name: "test2",
+                nickname: "test2",
+                balance: 123131,
+                email: "mail@example.com",
+              },
+            ],
+            version: 123.34534,
+          },
+          project_id: "pid",
+        )
+      end
+
+      it "raises TableSync::DataError" do
+        expect { fire_update_event }.to raise_error(TableSync::DataError)
+      end
+    end
   end
 
   describe "avoid dead locks" do


### PR DESCRIPTION
```ruby

dataset.insert_conflict(target: {}, update: {}).multi_insert([{a: 1, b: 1}, {b: 2}])
dataset.insert_conflict(target: {}, update: {}).multi_insert([{b: 2}, {a: 1, b: 1}])

INSERT INTO "gambling"."users" ("a", "b") VALUES (1, 1), (NULL, 2) ON CONFLICT (NULL) DO UPDATE SET
INSERT INTO "gambling"."users" ("b") VALUES (2), (1) ON CONFLICT (NULL) DO UPDATE SET
```