### PR TITLE
Skip publish when object is new and event is destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.0.2] - 2021-12-01
+### Fixed
+- Fixed bug: skip publish when object is new and event is destroy for ActiveRecord
+
 ## [6.0.1] - 2021-11-30
 ### Fixed
 - fixed docs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_sync (6.0.1)
+    table_sync (6.0.2)
       memery
       rabbit_messaging
       rails
@@ -91,7 +91,7 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    lamian (1.2.0)
+    lamian (1.4.0)
       rails (>= 4.2)
     loofah (2.12.0)
       crass (~> 1.0.2)
@@ -103,9 +103,11 @@ GEM
       ruby2_keywords (~> 0.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     nio4r (2.5.8)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.0.0)
@@ -207,7 +209,7 @@ GEM
     sequel (5.43.0)
     serverengine (2.0.7)
       sigdump (~> 0.2.2)
-    set (1.0.1)
+    set (1.0.2)
     sigdump (0.2.4)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -228,9 +230,9 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.2)
-      actionpack (>= 4.0)
-      activesupport (>= 4.0)
+    sprockets-rails (3.4.1)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     tainbox (2.1.2)
       activesupport

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,7 +41,7 @@ class SomeOtherModel < Sequel::Model
 end
 ```
 
-ActiveRecord features:
+Features of ActiveRecord:
 
 - Skip publish when object is new and event is destroy. 
 
@@ -52,6 +52,7 @@ Example:
   # `TableSync::Publishing::Single` isn't creating and message isn't sending to rabbit 
 ```
 
+If we repeat this example for Sequel we got error 'Sequel::NoExistingObject'
 
 
 ## Manual

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,19 +41,22 @@ class SomeOtherModel < Sequel::Model
 end
 ```
 
-Features of ActiveRecord:
+### Non persisted record destruction
 
-- Skip publish when object is new and event is destroy. 
+Sometimes destroy event can happen for non persisted record. In this case we can expect the following:
 
-Example: 
+For Sequel: 'Sequel::NoExistingObject' is raised. (This is default Sequel behaviour)
+For Active Record: Publishing is skipped.
+
+Example:
 
 ```ruby
-  user = User.new.destroy!
-  # `TableSync::Publishing::Single` isn't creating and message isn't sending to rabbit 
+ # ActiveRecord
+  user = User.new.destroy! # Publishing is skipped.
+  
+ # Sequel 
+  user = User.new.destroy! # raise Sequel::NoExistingObject
 ```
-
-If we repeat this example for Sequel we got error 'Sequel::NoExistingObject'
-
 
 ## Manual
 

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -41,6 +41,19 @@ class SomeOtherModel < Sequel::Model
 end
 ```
 
+ActiveRecord features:
+
+- Skip publish when object is new and event is destroy. 
+
+Example: 
+
+```ruby
+  user = User.new.destroy!
+  # `TableSync::Publishing::Single` isn't creating and message isn't sending to rabbit 
+```
+
+
+
 ## Manual
 
 Directly call one of the publishers. It's the best if you need to sync a lot of data.

--- a/lib/table_sync/setup/active_record.rb
+++ b/lib/table_sync/setup/active_record.rb
@@ -8,6 +8,8 @@ module TableSync::Setup
       options = options_exposed_for_block
 
       object_class.after_commit(on: event) do
+        return if (self.new_record? && self.destroyed?)
+
         if instance_eval(&options[:if]) && !instance_eval(&options[:unless])
           TableSync::Publishing::Single.new(
             object_class: self.class.name,

--- a/lib/table_sync/setup/active_record.rb
+++ b/lib/table_sync/setup/active_record.rb
@@ -8,7 +8,7 @@ module TableSync::Setup
       options = options_exposed_for_block
 
       object_class.after_commit(on: event) do
-        next if (self.new_record? && self.destroyed?)
+        next if new_record? && destroyed?
 
         if instance_eval(&options[:if]) && !instance_eval(&options[:unless])
           TableSync::Publishing::Single.new(

--- a/lib/table_sync/setup/active_record.rb
+++ b/lib/table_sync/setup/active_record.rb
@@ -8,7 +8,7 @@ module TableSync::Setup
       options = options_exposed_for_block
 
       object_class.after_commit(on: event) do
-        return if (self.new_record? && self.destroyed?)
+        next if (self.new_record? && self.destroyed?)
 
         if instance_eval(&options[:if]) && !instance_eval(&options[:unless])
           TableSync::Publishing::Single.new(

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "6.0.1"
+  VERSION = "6.0.2"
 end

--- a/spec/setup/active_record_spec.rb
+++ b/spec/setup/active_record_spec.rb
@@ -26,4 +26,22 @@ describe TableSync::Setup::ActiveRecord do
       setup_sync
     end
   end
+
+  context "when event destroy" do
+    before { setup_sync }
+
+    context "when user is persisted" do
+      specify do
+        expect(job).to receive(:perform_at)
+        test_class.first.destroy
+      end
+    end
+
+    context "when user is new record" do
+      specify do
+        expect(job).not_to receive(:perform_at)
+        test_class.new.destroy
+      end
+    end
+  end
 end

--- a/spec/setup/active_record_spec.rb
+++ b/spec/setup/active_record_spec.rb
@@ -30,13 +30,6 @@ describe TableSync::Setup::ActiveRecord do
   context "when event destroy" do
     before { setup_sync }
 
-    context "when user is persisted" do
-      specify do
-        expect(job).to receive(:perform_at)
-        test_class.first.destroy
-      end
-    end
-
     context "when user is new record" do
       specify do
         expect(job).not_to receive(:perform_at)

--- a/spec/setup/sequel_spec.rb
+++ b/spec/setup/sequel_spec.rb
@@ -31,13 +31,6 @@ describe TableSync::Setup::Sequel do
   context "when event destroy" do
     before { setup_sync }
 
-    context "when user is persisted" do
-      specify do
-        expect(job).to receive(:perform_at)
-        test_class.first.destroy
-      end
-    end
-
     context "when user is new record" do
       specify do
         expect(job).not_to receive(:perform_at)

--- a/spec/setup/sequel_spec.rb
+++ b/spec/setup/sequel_spec.rb
@@ -27,4 +27,22 @@ describe TableSync::Setup::Sequel do
       setup_sync
     end
   end
+
+  context "when event destroy" do
+    before { setup_sync }
+
+    context "when user is persisted" do
+      specify do
+        expect(job).to receive(:perform_at)
+        test_class.first.destroy
+      end
+    end
+
+    context "when user is new record" do
+      specify do
+        expect(job).not_to receive(:perform_at)
+        expect { test_class.new.destroy }.to raise_error(Sequel::NoExistingObject)
+      end
+    end
+  end
 end

--- a/spec/support/shared/setup.rb
+++ b/spec/support/shared/setup.rb
@@ -64,4 +64,27 @@ shared_examples "setup: enqueue job behaviour" do |test_class_name|
       include_examples "doesn't enqueue job"
     end
   end
+
+  context "when event destroy" do
+    before { setup_sync }
+
+    context "when user is persisted" do
+      specify do
+        expect(job).to receive(:perform_at)
+        test_class.first.destroy
+      end
+    end
+
+    context "when user is new record" do
+      specify do
+        expect(job).not_to receive(:perform_at)
+
+        if test_class_name == "TestARUser"
+          test_class.new.destroy
+        else
+          expect { test_class.new.destroy }.to raise_error(Sequel::NoExistingObject)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/shared/setup.rb
+++ b/spec/support/shared/setup.rb
@@ -64,27 +64,4 @@ shared_examples "setup: enqueue job behaviour" do |test_class_name|
       include_examples "doesn't enqueue job"
     end
   end
-
-  context "when event destroy" do
-    before { setup_sync }
-
-    context "when user is persisted" do
-      specify do
-        expect(job).to receive(:perform_at)
-        test_class.first.destroy
-      end
-    end
-
-    context "when user is new record" do
-      specify do
-        expect(job).not_to receive(:perform_at)
-
-        if test_class_name == "TestARUser"
-          test_class.new.destroy
-        else
-          expect { test_class.new.destroy }.to raise_error(Sequel::NoExistingObject)
-        end
-      end
-    end
-  end
 end

--- a/spec/support/shared/setup.rb
+++ b/spec/support/shared/setup.rb
@@ -64,4 +64,15 @@ shared_examples "setup: enqueue job behaviour" do |test_class_name|
       include_examples "doesn't enqueue job"
     end
   end
+
+  context "when event destroy" do
+    before { setup_sync }
+
+    context "when user is persisted" do
+      specify do
+        expect(job).to receive(:perform_at)
+        test_class.first.destroy
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added check when object is new and event is destroy. Example:
```
user = User.new.destroy!
# job isn't creating and message isn't sending to rabbit 
```