### PR TITLE
Fix: attrs for destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.3.0] -- 2023-07-24
+### Changed
+- Send all original attributes for `delete` events instead of just PK.
+
 ## [6.2.0] - 2023-06-29
 ### Changed
 - `rabbit_messaging` gem version is locked on `~> 0.13` in order to provide a way to keep "up-to-date"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_sync (6.2.0)
+    table_sync (6.3.0)
       memery
       rabbit_messaging (~> 0.13)
       rails

--- a/lib/table_sync/orm_adapter/base.rb
+++ b/lib/table_sync/orm_adapter/base.rb
@@ -53,7 +53,7 @@ module TableSync::ORMAdapter
       if object.respond_to?(:attributes_for_destroy)
         object.attributes_for_destroy
       else
-        needle
+        attributes
       end
     end
 

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "6.2.0"
+  VERSION = "6.3.0"
 end

--- a/spec/publishing/data/objects_spec.rb
+++ b/spec/publishing/data/objects_spec.rb
@@ -72,8 +72,6 @@ describe TableSync::Publishing::Data::Objects do
       let(:resolved_event) { :destroy }
 
       context "without #attributes_for_destroy" do
-        let(:expected_attributes) { { id: object.object.id } }
-
         include_examples "correctly constructs data for message"
       end
 


### PR DESCRIPTION
- Send all original attributes for `delete` events instead of just PK