### PR TITLE
Add required fields validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [6.4.1] - 2023-08-15
+### Added
+- Required fields validation for the Raw and Batch publishers.
+
 ## [6.4.0] - 2023-08-15
 ### Changed
 -  Fix sort in receiving (#79).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_sync (6.4.0)
+    table_sync (6.4.1)
       memery
       rabbit_messaging (~> 0.13)
       rails

--- a/lib/table_sync/publishing/batch.rb
+++ b/lib/table_sync/publishing/batch.rb
@@ -2,6 +2,7 @@
 
 class TableSync::Publishing::Batch
   include Tainbox
+  include TableSync::Utils::RequiredValidator
 
   attribute :object_class
   attribute :original_attributes
@@ -10,6 +11,8 @@ class TableSync::Publishing::Batch
   attribute :headers
 
   attribute :event, default: :update
+
+  require_attributes :object_class, :original_attributes
 
   def publish_later
     job.perform_later(job_attributes)

--- a/lib/table_sync/publishing/raw.rb
+++ b/lib/table_sync/publishing/raw.rb
@@ -2,6 +2,7 @@
 
 class TableSync::Publishing::Raw
   include Tainbox
+  include TableSync::Utils::RequiredValidator
 
   attribute :model_name
   attribute :table_name
@@ -12,6 +13,8 @@ class TableSync::Publishing::Raw
   attribute :headers
 
   attribute :event, default: :update
+
+  require_attributes :model_name, :original_attributes
 
   def publish_now
     message.publish

--- a/lib/table_sync/utils.rb
+++ b/lib/table_sync/utils.rb
@@ -5,5 +5,6 @@ module TableSync
     require_relative "utils/proc_array"
     require_relative "utils/proc_keywords_resolver"
     require_relative "utils/interface_checker"
+    require_relative "utils/required_validator"
   end
 end

--- a/lib/table_sync/utils/required_validator.rb
+++ b/lib/table_sync/utils/required_validator.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module TableSync::Utils::RequiredValidator
+  module PrependedInitialization
+    def initialize(*)
+      super
+
+      not_filled_attrs = calculate_not_filled_attributes
+      if not_filled_attrs.present?
+        raise(
+          ArgumentError,
+          "Some of required attributes is not provided: #{not_filled_attrs.inspect}",
+        )
+      end
+    end
+  end
+
+  module ClassMethods
+    def require_attributes(*attributes)
+      _required_attributes.push(*attributes)
+    end
+
+    def _required_attributes
+      @_required_attributes ||= []
+    end
+  end
+
+  module InstanceMethods
+    private
+
+    def calculate_not_filled_attributes
+      attributes
+        .select { |key, value| key.in?(self.class._required_attributes) && value.blank? }
+        .keys
+    end
+  end
+
+  def self.included(klass)
+    klass.prepend(PrependedInitialization)
+    klass.extend(ClassMethods)
+    klass.include(InstanceMethods)
+  end
+end

--- a/lib/table_sync/version.rb
+++ b/lib/table_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSync
-  VERSION = "6.4.0"
+  VERSION = "6.4.1"
 end

--- a/spec/publishing/batch_spec.rb
+++ b/spec/publishing/batch_spec.rb
@@ -24,6 +24,9 @@ RSpec.describe TableSync::Publishing::Batch do
 
   include_examples "publisher#publish_now with stubbed message",
                    TableSync::Publishing::Message::Batch
+  include_examples "publisher#new without expected fields",
+                   TableSync::Publishing::Batch,
+                   %i[object_class original_attributes]
 
   context "real user" do
     context "sequel" do

--- a/spec/publishing/raw_spec.rb
+++ b/spec/publishing/raw_spec.rb
@@ -36,4 +36,8 @@ RSpec.describe TableSync::Publishing::Raw do
     include_examples "publisher#publish_now without stubbed message",
                      TableSync::Publishing::Message::Raw
   end
+
+  include_examples "publisher#new without expected fields",
+                   TableSync::Publishing::Raw,
+                   %i[model_name original_attributes]
 end

--- a/spec/support/shared/publishers.rb
+++ b/spec/support/shared/publishers.rb
@@ -54,6 +54,22 @@ shared_examples "publisher#publish_now without stubbed message" do
   end
 end
 
+# needs let(:attributes)
+shared_examples "publisher#new without expected fields" do |publisher_class, required_attributes|
+  required_attributes.each do |attribute|
+    context "without #{attribute}" do
+      it "raises an error" do
+        expect { publisher_class.new(attributes.except(attribute)) }.to raise_error do |error|
+          expect(error).to be_an_instance_of(ArgumentError)
+          expect(error.message).to eq(
+            "Some of required attributes is not provided: [:#{attribute}]",
+          )
+        end
+      end
+    end
+  end
+end
+
 # needs let(:existing_user)
 shared_examples "publisher#publish_now with real user, for given orm" do |orm|
   let(:user) { DB[:users].where(id: existing_user.id).first }


### PR DESCRIPTION
# Added

- `TableSync::Utils::RequiredValidator`, which provides `require_attributes` DSL.
- Validate required attributes for the `Raw` and `Batch` publishers.