### PR TITLE
V610 custom version patch(for review only)

### DIFF
--- a/lib/table_sync/publishing/batch.rb
+++ b/lib/table_sync/publishing/batch.rb
@@ -5,7 +5,7 @@ class TableSync::Publishing::Batch
 
   attribute :object_class
   attribute :original_attributes
-
+  attribute :custom_version
   attribute :routing_key
   attribute :headers
 

--- a/lib/table_sync/publishing/data/objects.rb
+++ b/lib/table_sync/publishing/data/objects.rb
@@ -2,18 +2,19 @@
 
 module TableSync::Publishing::Data
   class Objects
-    attr_reader :objects, :event
+    attr_reader :objects, :event, :custom_version
 
-    def initialize(objects:, event:)
-      @objects = objects
-      @event   = TableSync::Event.new(event)
+    def initialize(objects:, event:, custom_version:)
+      @objects        = objects
+      @event          = TableSync::Event.new(event)
+      @custom_version = custom_version
     end
 
     def construct
       {
         model: model,
         attributes: attributes_for_sync,
-        version: version,
+        version: custom_version || version,
         event: event.resolve,
         metadata: event.metadata,
       }

--- a/lib/table_sync/publishing/data/raw.rb
+++ b/lib/table_sync/publishing/data/raw.rb
@@ -2,19 +2,20 @@
 
 module TableSync::Publishing::Data
   class Raw
-    attr_reader :model_name, :attributes_for_sync, :event
+    attr_reader :model_name, :attributes_for_sync, :event, :custom_version
 
-    def initialize(model_name:, attributes_for_sync:, event:)
+    def initialize(model_name:, attributes_for_sync:, event:, custom_version:)
       @model_name = model_name
       @attributes_for_sync = attributes_for_sync
       @event = TableSync::Event.new(event)
+      @custom_version = custom_version
     end
 
     def construct
       {
         model: model_name,
         attributes: wrapped_attributes_for_sync,
-        version: version,
+        version: custom_version || version,
         event: event.resolve,
         metadata: event.metadata,
       }

--- a/lib/table_sync/publishing/message/base.rb
+++ b/lib/table_sync/publishing/message/base.rb
@@ -6,6 +6,7 @@ module TableSync::Publishing::Message
 
     attr_reader :objects
 
+    attribute :custom_version
     attribute :object_class
     attribute :original_attributes
     attribute :event
@@ -44,7 +45,9 @@ module TableSync::Publishing::Message
 
     def data
       TableSync::Publishing::Data::Objects.new(
-        objects: objects, event: event,
+        objects: objects,
+        event: event,
+        custom_version: custom_version,
       ).construct
     end
 

--- a/lib/table_sync/publishing/message/raw.rb
+++ b/lib/table_sync/publishing/message/raw.rb
@@ -24,12 +24,16 @@ module TableSync::Publishing::Message
 
     def notify!
       TableSync::Instrument.notify(
-        table: table_name,
-        schema: schema_name,
+        table: table_name || model_naming.table,
+        schema: schema_name || model_naming.schema,
         event: event,
         count: original_attributes.count,
         direction: :publish,
       )
+    end
+
+    def model_naming
+      TableSync.publishing_adapter.model_naming(model_name.constantize)
     end
 
     # MESSAGE PARAMS

--- a/lib/table_sync/publishing/message/raw.rb
+++ b/lib/table_sync/publishing/message/raw.rb
@@ -11,7 +11,7 @@ module TableSync::Publishing::Message
 
     attribute :routing_key
     attribute :headers
-
+    attribute :custom_version
     attribute :event
 
     def publish
@@ -41,6 +41,7 @@ module TableSync::Publishing::Message
     def data
       TableSync::Publishing::Data::Raw.new(
         model_name: model_name, attributes_for_sync: original_attributes, event: event,
+        custom_version: custom_version,
       ).construct
     end
 

--- a/lib/table_sync/publishing/raw.rb
+++ b/lib/table_sync/publishing/raw.rb
@@ -7,7 +7,7 @@ class TableSync::Publishing::Raw
   attribute :table_name
   attribute :schema_name
   attribute :original_attributes
-
+  attribute :custom_version
   attribute :routing_key
   attribute :headers
 

--- a/lib/table_sync/publishing/single.rb
+++ b/lib/table_sync/publishing/single.rb
@@ -7,7 +7,7 @@ class TableSync::Publishing::Single
   attribute :object_class
   attribute :original_attributes
   attribute :debounce_time
-
+  attribute :custom_version
   attribute :event, Symbol, default: :update
 
   # expect job to have perform_at method


### PR DESCRIPTION
It contains features from `v604_custom_version_patch` branch with some additions based on table_sync/v6.1.0.

Addition: for `notify!` method we keep  `model_naming` as fallback in case of missing `table_name` and `schema_name` attributes.