### PR TITLE
Фикс экспирации кеша

### DIFF
--- a/lib/table_sync/publishing/helpers/debounce.rb
+++ b/lib/table_sync/publishing/helpers/debounce.rb
@@ -124,11 +124,11 @@ module TableSync::Publishing::Helpers
     end
 
     def cache_next_sync_time
-      Rails.cache.write(
-        cache_key,
-        next_sync_time,
-        expires_at: next_sync_time + debounce_time.seconds,
-      )
+      expires_at = next_sync_time + debounce_time.seconds
+      expires_in = expires_at - Time.current
+      return if expires_in.negative?
+
+      Rails.cache.write(cache_key, next_sync_time, expires_in:)
     end
 
     def cache_key


### PR DESCRIPTION
Сейчас если поставить debounce_time = 0, либо слишком низкое значение, то получаем ошибку:
```
ArgumentError: Cache expiration time is invalid, cannot be negative: -1.342383599
```

Поправил логику, чтобы оно не падало.